### PR TITLE
fix mds name invalidate when up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,7 @@ services:
   mds1:
     image: ceph/daemon:${CEPH_CONTAINER_VERSION}
     command: "mds"
+    hostname: "ceph-mds1-host"
     environment:
       CEPHFS_CREATE: 1
       LANG: ${LANG}


### PR DESCRIPTION
Fix #2 mds up failed when hostname start with numeric digit